### PR TITLE
compiles now warning free. fixed bugs in dpt conversion.

### DIFF
--- a/src/ActionRingBuffer.h
+++ b/src/ActionRingBuffer.h
@@ -53,16 +53,16 @@ class ActionRingBuffer {
   public : 
 
     // Constructor
-    ActionRingBuffer()
-    {
-      _head = 0;
-      _tail = 0;
-      _elementsCurrentNb = 0;
-      _size = size;
+    ActionRingBuffer():
+      _head(0),
+      _tail(0),
+      _size(size),
+      _elementsCurrentNb(0)
     #ifdef ACTIONRINGBUFFER_STAT
-      _elementsMaxNb = 0; // MAX nb of elements
-      _lostElementsNb = 0;    // nb of lost elements
+      , _elementsMaxNb(0) // MAX nb of elements
+      , _lostElementsNb(0)    // nb of lost elements
     #endif
+    {
     };
 
 

--- a/src/DebugUtil.cpp
+++ b/src/DebugUtil.cpp
@@ -24,7 +24,7 @@ int DebugUtil::freeRam() {
 #endif
 }
 
-void DebugUtil::print(char *format, ...) {
+void DebugUtil::print(const char *format, ...) {
     if (_printstream) {
         char buf[128]; // limit to 128chars
         va_list args;
@@ -54,7 +54,7 @@ void DebugUtil::print(const __FlashStringHelper *format, ...) {
     }
 }
 
-void DebugUtil::println(char *format, ...) {
+void DebugUtil::println(const char *format, ...) {
     if (_printstream) {
 
         char buf[128]; // limit to 128chars

--- a/src/DebugUtil.h
+++ b/src/DebugUtil.h
@@ -41,14 +41,14 @@
 
 #define BYTETOBINARYPATTERN "%d%d%d%d%d%d%d%d"
 #define BYTETOBINARY(byte)  \
-  (byte & 0x80 ? 1 : 0), \
-  (byte & 0x40 ? 1 : 0), \
-  (byte & 0x20 ? 1 : 0), \
-  (byte & 0x10 ? 1 : 0), \
-  (byte & 0x08 ? 1 : 0), \
-  (byte & 0x04 ? 1 : 0), \
-  (byte & 0x02 ? 1 : 0), \
-  (byte & 0x01 ? 1 : 0) 
+  ((byte & 0x80) ? 1 : 0), \
+  ((byte & 0x40) ? 1 : 0), \
+  ((byte & 0x20) ? 1 : 0), \
+  ((byte & 0x10) ? 1 : 0), \
+  ((byte & 0x08) ? 1 : 0), \
+  ((byte & 0x04) ? 1 : 0), \
+  ((byte & 0x02) ? 1 : 0), \
+  ((byte & 0x01) ? 1 : 0) 
 
 
 class DebugUtil {
@@ -70,9 +70,9 @@ public:
     
     int freeRam();
     
-    void print(char *format, ...);
+    void print(const char *format, ...);
     void print(const __FlashStringHelper *format, ...);
-    void println(char *format, ...);
+    void println(const char *format, ...);
     void println(const __FlashStringHelper *format, ...);
 };
 

--- a/src/KnxDevice.cpp
+++ b/src/KnxDevice.cpp
@@ -89,7 +89,8 @@ e_KnxDeviceStatus KnxDevice::begin(HardwareSerial& serial, word physicalAddr) {
     _state = IDLE;
     DEBUG_PRINTLN(F("Init successful"));
     _lastInitTimeMillis = millis();
-    _lastTXTimeMicros = _lastRXTimeMicros = micros();
+    _lastRXTimeMicros = micros();
+    _lastTXTimeMicros = _lastRXTimeMicros;
 #if defined(KNXDEVICE_DEBUG_INFO)
     _nbOfInits = 0;
 #endif
@@ -501,7 +502,7 @@ void KnxDevice::GetTpUartEvents(e_KnxTpUartEvent event) {
 // Static TxTelegramAck() function called by the KnxTpUart layer (callback)
 
 void KnxDevice::TxTelegramAck(e_TpUartTxAck 
-#ifdef KNXDevice_DEBUG
+#ifdef KNXDevice_DEBUG // ifdef to suppress compiler warning about unused variable when not in debug mode
 		value
 #endif // KNXDevice_DEBUG
 		) {

--- a/src/KnxDevice.cpp
+++ b/src/KnxDevice.cpp
@@ -43,17 +43,18 @@ KnxDevice& Knx = KnxDevice::Knx;
 
 // Constructor
 
-KnxDevice::KnxDevice() {
-    _state = INIT;
-    _tpuart = NULL;
-    _txActionList = ActionRingBuffer<type_tx_action, ACTIONS_QUEUE_SIZE>();
-    _initCompleted = false;
-    _initIndex = 0;
-    _rxTelegram = NULL;
+KnxDevice::KnxDevice(): 
+    _state(INIT),
+    _tpuart(0),
+    _txActionList( ActionRingBuffer<type_tx_action, ACTIONS_QUEUE_SIZE>() ),
+    _initCompleted(false),
+    _initIndex(0),
+    _rxTelegram(0)
 #if defined(KNXDEVICE_DEBUG_INFO)
-    _nbOfInits = 0;
-    _debugStrPtr = NULL;
+    , _nbOfInits(0)
+    , _debugStrPtr(0)
 #endif
+{	
     //AC
     _progComObj.SetAddr(G_ADDR(15, 7, 255));
     _progComObj.setActive(true);
@@ -69,6 +70,7 @@ int KnxDevice::getNumberOfComObjects() {
 // else return KNX_DEVICE_OK
 
 e_KnxDeviceStatus KnxDevice::begin(HardwareSerial& serial, word physicalAddr) {
+    delete _tpuart; // always safe to delete null ptr
     _tpuart = new KnxTpUart(serial, physicalAddr, NORMAL);
     _rxTelegram = &_tpuart->GetReceivedTelegram();
     //delay(10000); // Workaround for init issue with bus-powered arduino
@@ -336,8 +338,7 @@ template e_KnxDeviceStatus KnxDevice::write <double>(byte objectIndex, double va
  */
 e_KnxDeviceStatus KnxDevice::write(byte objectIndex, byte valuePtr[]) {
     type_tx_action action;
-    type_tx_action action2;
-    byte *dptValue;
+    //type_tx_action action2;
     
     // get length of comobj for copying value into tx-action struct
     KnxComObject* comObj = (objectIndex == 255 ? &_progComObj : &_comObjectsList[objectIndex]);    
@@ -357,7 +358,7 @@ e_KnxDeviceStatus KnxDevice::write(byte objectIndex, byte valuePtr[]) {
         action.index = objectIndex;
         
         // allocate the memory for long value
-        dptValue = (byte *) malloc(length - 1); 
+        byte *dptValue = (byte *) malloc(length - 1); 
         
         for (byte i = 0; i < length - 1; i++) {
             dptValue[i] = valuePtr[i]; // copy value
@@ -499,7 +500,11 @@ void KnxDevice::GetTpUartEvents(e_KnxTpUartEvent event) {
 
 // Static TxTelegramAck() function called by the KnxTpUart layer (callback)
 
-void KnxDevice::TxTelegramAck(e_TpUartTxAck value) {
+void KnxDevice::TxTelegramAck(e_TpUartTxAck 
+#ifdef KNXDevice_DEBUG
+		value
+#endif // KNXDevice_DEBUG
+		) {
     Knx._state = IDLE;
 #ifdef KNXDevice_DEBUG
     if (value != ACK_RESPONSE) {

--- a/src/KnxDevice.cpp
+++ b/src/KnxDevice.cpp
@@ -89,7 +89,7 @@ e_KnxDeviceStatus KnxDevice::begin(HardwareSerial& serial, word physicalAddr) {
     _state = IDLE;
     DEBUG_PRINTLN(F("Init successful"));
     _lastInitTimeMillis = millis();
-    _lastTXTimeMicros = _lastTXTimeMicros = micros();
+    _lastTXTimeMicros = _lastRXTimeMicros = micros();
 #if defined(KNXDEVICE_DEBUG_INFO)
     _nbOfInits = 0;
 #endif
@@ -563,7 +563,7 @@ template <typename T> e_KnxDeviceStatus ConvertFromDpt(const byte dptOriginValue
             return KNX_DEVICE_NOT_IMPLEMENTED;
             break;
 
-        default: KNX_DEVICE_ERROR;
+        default: return KNX_DEVICE_ERROR;
     }
 }
 
@@ -633,7 +633,7 @@ template <typename T> e_KnxDeviceStatus ConvertToDpt(T originValue, byte dptDest
             return KNX_DEVICE_NOT_IMPLEMENTED;
             break;
 
-        default: KNX_DEVICE_ERROR;
+        default: return KNX_DEVICE_ERROR;
     }
 }
 

--- a/src/KnxDevice.h
+++ b/src/KnxDevice.h
@@ -272,7 +272,11 @@ inline void KnxDevice::SetDebugString(String *strPtr) {_debugStrPtr = strPtr;}
 #endif
 
 
-inline void KnxDevice::DebugInfo(const char comment[]) const
+inline void KnxDevice::DebugInfo(const char
+#if defined(KNXDEVICE_DEBUG_INFO)
+	       comment
+#endif
+	       []) const
 {
 #if defined(KNXDEVICE_DEBUG_INFO)
 	if (_debugStrPtr != NULL) *_debugStrPtr += String(_debugInfoText) + String(comment);

--- a/src/KnxDevice.h
+++ b/src/KnxDevice.h
@@ -273,7 +273,7 @@ inline void KnxDevice::SetDebugString(String *strPtr) {_debugStrPtr = strPtr;}
 
 
 inline void KnxDevice::DebugInfo(const char
-#if defined(KNXDEVICE_DEBUG_INFO)
+#if defined(KNXDEVICE_DEBUG_INFO) // ifdef to suppress compiler warning about unused variable when not in debug mode
 	       comment
 #endif
 	       []) const

--- a/src/KnxTpUart.h
+++ b/src/KnxTpUart.h
@@ -321,7 +321,7 @@ inline boolean KnxTpUart::IsActive(void) const
 
 
 inline void KnxTpUart::SetDebugString(String *
-#if defined(KNXTPUART_DEBUG_INFO) || defined(KNXTPUART_DEBUG_ERROR)
+#if defined(KNXTPUART_DEBUG_INFO) || defined(KNXTPUART_DEBUG_ERROR) // ifdef to suppress compiler warning about unused variable when not in debug mode
 		strPtr
 #endif
 		)
@@ -333,7 +333,7 @@ inline void KnxTpUart::SetDebugString(String *
 
 
 inline void KnxTpUart::DebugInfo(const char 
-#if defined(KNXTPUART_DEBUG_INFO)
+#if defined(KNXTPUART_DEBUG_INFO) // ifdef to suppress compiler warning about unused variable when not in debug mode
 		comment
 #endif
 		[]) const
@@ -345,7 +345,7 @@ inline void KnxTpUart::DebugInfo(const char
 
 
 inline void KnxTpUart::DebugError(const char 
-#if defined(KNXTPUART_DEBUG_ERROR)
+#if defined(KNXTPUART_DEBUG_ERROR) // ifdef to suppress compiler warning about unused variable when not in debug mode
 		comment
 #endif
 		[]) const

--- a/src/KnxTpUart.h
+++ b/src/KnxTpUart.h
@@ -320,7 +320,11 @@ inline boolean KnxTpUart::IsActive(void) const
 
 
 
-inline void KnxTpUart::SetDebugString(String *strPtr)
+inline void KnxTpUart::SetDebugString(String *
+#if defined(KNXTPUART_DEBUG_INFO) || defined(KNXTPUART_DEBUG_ERROR)
+		strPtr
+#endif
+		)
 {
 #if defined(KNXTPUART_DEBUG_INFO) || defined(KNXTPUART_DEBUG_ERROR)
    _debugStrPtr = strPtr;
@@ -328,7 +332,11 @@ inline void KnxTpUart::SetDebugString(String *strPtr)
 }
 
 
-inline void KnxTpUart::DebugInfo(const char comment[]) const
+inline void KnxTpUart::DebugInfo(const char 
+#if defined(KNXTPUART_DEBUG_INFO)
+		comment
+#endif
+		[]) const
 {
 #if defined(KNXTPUART_DEBUG_INFO)
   if (_debugStrPtr != NULL) *_debugStrPtr += String(_debugInfoText) + String(comment);
@@ -336,7 +344,11 @@ inline void KnxTpUart::DebugInfo(const char comment[]) const
 }
 
 
-inline void KnxTpUart::DebugError(const char comment[]) const
+inline void KnxTpUart::DebugError(const char 
+#if defined(KNXTPUART_DEBUG_ERROR)
+		comment
+#endif
+		[]) const
 {
 #if defined(KNXTPUART_DEBUG_ERROR)
   if (_debugStrPtr != NULL) *_debugStrPtr += String(_debugErrorText) + String(comment);

--- a/src/KonnektingDevice.cpp
+++ b/src/KonnektingDevice.cpp
@@ -148,7 +148,7 @@ void KonnektingDevice::init(HardwareSerial& serial,
 
     _deviceFlags = memoryRead(EEPROM_DEVICE_FLAGS);
 
-    DEBUG_PRINTLN(F("_deviceFlags: "BYTETOBINARYPATTERN), BYTETOBINARY(_deviceFlags));
+    DEBUG_PRINTLN(F("_deviceFlags: " BYTETOBINARYPATTERN), BYTETOBINARY(_deviceFlags));
 
     _individualAddress = P_ADDR(1, 1, 254);
     if (!isFactorySetting()) {
@@ -364,7 +364,7 @@ bool KonnektingDevice::internalComObject(byte index) {
             Knx.read(PROGCOMOBJ_INDEX, buffer);
 #ifdef DEBUG_PROTOCOL
             for (int i = 0; i < 14; i++) {
-                DEBUG_PRINTLN(F("buffer[%d]\thex=0x%02x bin="BYTETOBINARYPATTERN), i, buffer[i], BYTETOBINARY(buffer[i]));
+                DEBUG_PRINTLN(F("buffer[%d]\thex=0x%02x bin=" BYTETOBINARYPATTERN), i, buffer[i], BYTETOBINARY(buffer[i]));
             }
 #endif
 
@@ -514,7 +514,7 @@ void KonnektingDevice::handleMsgWriteProgrammingMode(byte msg[]) {
     }
 }
 
-void KonnektingDevice::handleMsgReadProgrammingMode(byte msg[]) {
+void KonnektingDevice::handleMsgReadProgrammingMode(byte []) {
     DEBUG_PRINTLN(F("handleMsgReadProgrammingMode"));
     if (_progState) {
         byte response[14];
@@ -554,7 +554,7 @@ void KonnektingDevice::handleMsgWriteIndividualAddress(byte msg[]) {
     sendAck(0x00, 0x00);
 }
 
-void KonnektingDevice::handleMsgReadIndividualAddress(byte msg[]) {
+void KonnektingDevice::handleMsgReadIndividualAddress(byte []) {
     DEBUG_PRINTLN(F("handleMsgReadIndividualAddress"));
     byte response[14];
     response[0] = PROTOCOLVERSION;

--- a/src/KonnektingDevice.cpp
+++ b/src/KonnektingDevice.cpp
@@ -514,7 +514,8 @@ void KonnektingDevice::handleMsgWriteProgrammingMode(byte msg[]) {
     }
 }
 
-void KonnektingDevice::handleMsgReadProgrammingMode(byte []) {
+void KonnektingDevice::handleMsgReadProgrammingMode(byte /*msg*/[]) {
+    // to suppress compiler warning about unused variable, "msg" has been commented out
     DEBUG_PRINTLN(F("handleMsgReadProgrammingMode"));
     if (_progState) {
         byte response[14];
@@ -554,7 +555,8 @@ void KonnektingDevice::handleMsgWriteIndividualAddress(byte msg[]) {
     sendAck(0x00, 0x00);
 }
 
-void KonnektingDevice::handleMsgReadIndividualAddress(byte []) {
+void KonnektingDevice::handleMsgReadIndividualAddress(byte /*msg*/[]) {
+    // to suppress compiler warning about unused variable, "msg" has been commented out
     DEBUG_PRINTLN(F("handleMsgReadIndividualAddress"));
     byte response[14];
     response[0] = PROTOCOLVERSION;


### PR DESCRIPTION
ConvertFromDpt and ConvertToDpt were broken in error condition (reaches end of function, no return value set).
Furthermore, KnxDevice::begin had a double assignment to _lastTXTimeMicros. I thought it might be useful to set _lastRXTimeMicros here to have it initialized to a useful value.

Finally, I managed to get this compiling without any compiler warning.
In addition, cppcheck --enable=all is down to 2 (not relevant) warnings now.
Minor performance and style changes (use initialization lists for ctors, added some consts, moved a few ifdefs to avoid unused variables, moved variables to a smaller scope).

