### PR TITLE
Fix STM32 compatibility

### DIFF
--- a/src/DebugUtil.cpp
+++ b/src/DebugUtil.cpp
@@ -1,15 +1,9 @@
 #include "DebugUtil.h"
+#include "wiring_private.h"
 
 #if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_STM32)
     extern "C" char* sbrk(int incr);
     extern char *__brkval;
-#endif
-
-//workaround for va_start & va_end for STM32
-#if defined(ARDUINO_ARCH_STM32)
-#include <stdarg.h>
-#define va_start(v,l)	__builtin_va_start(v,l)
-#define va_end(v)	__builtin_va_end(v)
 #endif
 
 // DebugUtil unique instance creation


### PR DESCRIPTION
Remove workaround for va_start and va_end not defined

See:
https://github.com/stm32duino/Arduino_Core_STM32/issues/240

Fix:
https://github.com/stm32duino/Arduino_Core_STM32/pull/253

Build ok with core fix.